### PR TITLE
allow specifying a GitHub template

### DIFF
--- a/src/cli/AnalyzeCommand.res
+++ b/src/cli/AnalyzeCommand.res
@@ -19,7 +19,7 @@ external getExistingPRs: (
   array<string>,
 ) => promise<Map.t<string, SubmitCommand.pullRequest>> = "getExistingPRs"
 
-let analyzeCommand = async (jjFunctions: JJTypes.jjFunctions, ~remote: string, ~dryRun: bool) => {
+let analyzeCommand = async (jjFunctions: JJTypes.jjFunctions, ~remote: string, ~dryRun: bool, ~template: option<string>) => {
   Console.log("Fetching from remote...")
 
   try {
@@ -195,5 +195,6 @@ let analyzeCommand = async (jjFunctions: JJTypes.jjFunctions, ~remote: string, ~
     changeGraph,
     dryRun,
     remote,
+    template,
   )
 }

--- a/src/cli/AnalyzeCommand.res.mjs
+++ b/src/cli/AnalyzeCommand.res.mjs
@@ -20,7 +20,7 @@ function getExistingPRs(prim0, prim1, prim2, prim3) {
   return SubmitJs.getExistingPRs(prim0, prim1, prim2, prim3);
 }
 
-async function analyzeCommand(jjFunctions, remote, dryRun) {
+async function analyzeCommand(jjFunctions, remote, dryRun, template) {
   console.log("Fetching from remote...");
   try {
     await jjFunctions.gitFetch();
@@ -173,7 +173,7 @@ async function analyzeCommand(jjFunctions, remote, dryRun) {
         }));
   var segment = Core__Option.getExn(changeGraph.bookmarkedChangeIdToSegment.get(changeId$1), undefined);
   var logEntry = Core__Option.getExn(segment[0], undefined);
-  return await SubmitCommand.runSubmit(jjFunctions, Core__Option.getExn(logEntry.localBookmarks[0], undefined), changeGraph, dryRun, remote);
+  return await SubmitCommand.runSubmit(jjFunctions, Core__Option.getExn(logEntry.localBookmarks[0], undefined), changeGraph, dryRun, remote, template);
 }
 
 export {

--- a/src/cli/SubmitCommand.res.mjs
+++ b/src/cli/SubmitCommand.res.mjs
@@ -17,8 +17,8 @@ function analyzeSubmissionGraph(prim0, prim1) {
   return SubmitJs.analyzeSubmissionGraph(prim0, prim1);
 }
 
-function createSubmissionPlan(prim0, prim1, prim2, prim3, prim4) {
-  return SubmitJs.createSubmissionPlan(prim0, prim1, prim2, prim3, prim4);
+function createSubmissionPlan(prim0, prim1, prim2, prim3, prim4, prim5) {
+  return SubmitJs.createSubmissionPlan(prim0, prim1, prim2, prim3, prim4, prim5);
 }
 
 function createNarrowedSegments(prim0, prim1) {
@@ -73,7 +73,7 @@ function createExecutionCallbacks() {
         };
 }
 
-async function runSubmit(jjFunctions, bookmarkName, changeGraph, dryRun, remote) {
+async function runSubmit(jjFunctions, bookmarkName, changeGraph, dryRun, remote, template) {
   console.log("🔍 Analyzing submission requirements for: " + bookmarkName);
   var analysis = SubmitJs.analyzeSubmissionGraph(changeGraph, bookmarkName);
   console.log("✅ Found stack with " + analysis.relevantSegments.length.toString() + " segment(s)");
@@ -82,7 +82,7 @@ async function runSubmit(jjFunctions, bookmarkName, changeGraph, dryRun, remote)
   var githubConfig = await SubmitJs.getGitHubConfig(jjFunctions, remote);
   console.log("📋 Creating submission plan...");
   var narrowedSegments = SubmitJs.createNarrowedSegments(resolvedBookmarks, analysis);
-  var plan = await createSubmissionPlan(jjFunctions, githubConfig, narrowedSegments, remote, undefined);
+  var plan = await createSubmissionPlan(jjFunctions, githubConfig, narrowedSegments, remote, undefined, template);
   console.log("📍 GitHub repository: " + plan.repoInfo.owner + "/" + plan.repoInfo.repo);
   resolvedBookmarks.forEach(function (bookmark) {
         console.log(formatBookmarkStatus(bookmark, plan.existingPRs));
@@ -156,6 +156,13 @@ async function submitCommand(jjFunctions, bookmarkName, options) {
   } else {
     remote = Js_exn.raiseError("Options with remote are required");
   }
+  var template;
+  if (options !== undefined) {
+    var template$1 = options.template;
+    template = template$1 !== undefined ? Caml_option.valFromOption(template$1) : undefined;
+  } else {
+    template = undefined;
+  }
   if (dryRun) {
     console.log("🧪 DRY RUN: Simulating submission of bookmark: " + bookmarkName);
   } else {
@@ -179,7 +186,7 @@ async function submitCommand(jjFunctions, bookmarkName, options) {
     console.log("ℹ️  Found " + changeGraph.excludedBookmarkCount.toString() + " bookmarks on merge commits or their descendants, ignoring.\n   jj-stack works with linear stacking workflows. Consider using 'jj rebase' to linearize your history before creating stacked pull requests.");
     console.log();
   }
-  return await runSubmit(jjFunctions, bookmarkName, changeGraph, dryRun, remote);
+  return await runSubmit(jjFunctions, bookmarkName, changeGraph, dryRun, remote, template);
 }
 
 export {

--- a/src/lib/jjUtils.test.ts
+++ b/src/lib/jjUtils.test.ts
@@ -121,6 +121,7 @@ suite("stack detection", () => {
         ]),
       getDefaultBranch: () => Promise.resolve("main"),
       pushBookmark: () => Promise.resolve(),
+      getRoot: () => Promise.resolve("."),
     };
 
     const result = await buildChangeGraph(mockJj);
@@ -455,6 +456,7 @@ suite("stack detection", () => {
         ]),
       getDefaultBranch: () => Promise.resolve("main"),
       pushBookmark: () => Promise.resolve(),
+      getRoot: () => Promise.resolve("."),
     };
 
     const result = await buildChangeGraph(mockJj);

--- a/src/lib/jjUtils.ts
+++ b/src/lib/jjUtils.ts
@@ -21,6 +21,7 @@ export type JjFunctions = {
   ) => Promise<LogEntry[]>;
   getGitRemoteList: () => Promise<Array<{ name: string; url: string }>>;
   getDefaultBranch: () => Promise<string>;
+  getRoot: () => Promise<string>;
   pushBookmark: (bookmarkName: string, remote: string) => Promise<void>;
 };
 
@@ -60,7 +61,32 @@ export function createJjFunctions(config: JjConfig): JjFunctions {
     getDefaultBranch: () => getDefaultBranch(config),
     pushBookmark: (bookmarkName, remote) =>
       pushBookmark(config, bookmarkName, remote),
+    getRoot: () => getRoot(config),
   };
+}
+
+/**
+ * Returns the root of the repository
+ */
+function getRoot(config: JjConfig): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      config.binaryPath,
+      ["root"],
+      (error, stdout, stderr) => {
+        if (error) {
+          logger.error(
+            `Failed to find repo root: ${(error as Error).toString()}`,
+          );
+          return reject(error as Error);
+        }
+        if (stderr) {
+          logger.warn(`Got stderr response on jj root: ${stderr}`);
+        }
+        resolve(stdout.trim());
+      },
+    );
+  });
 }
 
 /**


### PR DESCRIPTION
I took a stab at allowing a pull request template file to get used when creating new PRs. There's some bikeshedding around the CLI parameter, but I've verified this works as intended. Sample usage is just `jst --template .github/push_request_template.md`. An improvement here would likely be to allow opening an editor, but that's not really necessary for my use-case, so I haven't done that yet. Happy to fold it in if you'd like, though.