### PR TITLE
Add support for github enterprise

### DIFF
--- a/src/cli/AuthCommand.res
+++ b/src/cli/AuthCommand.res
@@ -7,6 +7,7 @@ type source = [#"gh-cli" | #"env-var"]
 type authConfig = {
   token: string,
   source: source,
+  host: string,
 }
 
 type authDetails = {
@@ -20,11 +21,11 @@ type authResult =
   | Success({config: authConfig})
   | Failure({reason: string})
 
-@module("../lib/auth.js") external getGitHubAuthRaw: unit => promise<{..}> = "getGitHubAuth"
+@module("../lib/auth.js") external getGitHubAuthRaw: string => promise<{..}> = "getGitHubAuth"
 
 // Convert the JS object to a proper ReScript variant
 let getGitHubAuth = async () => {
-  let result = await getGitHubAuthRaw()
+  let result = await getGitHubAuthRaw("origin")
 
   switch result["kind"] {
   | "success" =>
@@ -36,6 +37,7 @@ let getGitHubAuth = async () => {
         | "env-var" => #"env-var"
         | _ => Exn.raiseError("Unexpected config source")
         },
+	host: result["config"]["host"],
       },
     })
   | "failure" => Failure({reason: result["reason"]})

--- a/src/cli/AuthCommand.res.mjs
+++ b/src/cli/AuthCommand.res.mjs
@@ -4,11 +4,11 @@ import * as Js_exn from "rescript/lib/es6/js_exn.js";
 import * as AuthJs from "../lib/auth.js";
 
 function getGitHubAuthRaw(prim) {
-  return AuthJs.getGitHubAuth();
+  return AuthJs.getGitHubAuth(prim);
 }
 
 async function getGitHubAuth() {
-  var result = await AuthJs.getGitHubAuth();
+  var result = await AuthJs.getGitHubAuth("origin");
   var match = result.kind;
   switch (match) {
     case "failure" :
@@ -33,7 +33,8 @@ async function getGitHubAuth() {
                 TAG: "Success",
                 config: {
                   token: result.config.token,
-                  source: tmp
+                  source: tmp,
+                  host: result.config.host
                 }
               };
     default:

--- a/src/cli/Cli.res
+++ b/src/cli/Cli.res
@@ -12,7 +12,7 @@
 @module("../lib/jjUtils.js")
 external createJjFunctions: JJTypes.jjConfig => JJTypes.jjFunctions = "createJjFunctions"
 @module("../lib/jjUtils.js")
-external isGitHubRemote: string => bool = "isGitHubRemote"
+external hasHost: (string, string) => bool = "hasHost"
 
 @unboxed type argumentValue = String(string) | Boolean(bool)
 
@@ -56,18 +56,28 @@ let resolveRemoteName = async (
   remotes: array<JJTypes.gitRemote>,
   userSpecified: option<string>,
 ): string => {
+
+  let githubInstance = "github.com" // TODO: use gh to guess this
   switch userSpecified {
   | Some(remoteName) => {
       let foundRemote = remotes->Array.find(r => r.name == remoteName)
       switch foundRemote {
       | Some(remote) => {
-          if !isGitHubRemote(remote.url) {
+          // if !isGitHubRemote(remote.url) {
+          //   Console.error(
+          //     `❌ Remote '${remoteName}' is not a GitHub remote. Only GitHub remotes are supported.`,
+          //   )
+          //   exit(1)
+          //   Js.Exn.raiseError("") // unreachable
+          // }
+          if !hasHost(remote.url, githubInstance) {
             Console.error(
               `❌ Remote '${remoteName}' is not a GitHub remote. Only GitHub remotes are supported.`,
             )
             exit(1)
             Js.Exn.raiseError("") // unreachable
           }
+
           remoteName
         }
       | None => {
@@ -78,7 +88,7 @@ let resolveRemoteName = async (
       }
     }
   | None => {
-      let githubRemotes = remotes->Array.filter(r => isGitHubRemote(r.url))
+      let githubRemotes = remotes->Array.filter(r => hasHost(r.url, githubInstance))
       switch githubRemotes->Array.length {
       | 0 => {
           Console.error("❌ No GitHub remotes found. At least one GitHub remote is required.")

--- a/src/cli/Cli.res.mjs
+++ b/src/cli/Cli.res.mjs
@@ -18,19 +18,20 @@ function createJjFunctions(prim) {
   return JjUtilsJs.createJjFunctions(prim);
 }
 
-function isGitHubRemote(prim) {
-  return JjUtilsJs.isGitHubRemote(prim);
+function hasHost(prim0, prim1) {
+  return JjUtilsJs.hasHost(prim0, prim1);
 }
 
 var help = "🔧 jj-stack - Jujutsu Git workflow automation\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nUSAGE:\n  jj-stack [COMMAND] [OPTIONS]\n\nCOMMANDS:\n  submit <bookmark>     Submit a bookmark and all downstack bookmarks as PRs\n    --dry-run           Show what would be done without making changes\n    --remote <name>     Use the specified Git remote (must be a GitHub remote)\n\n  auth test             Test GitHub authentication\n  auth help             Show authentication help\n\n  help, --help, -h      Show this help message\n\nDEFAULT BEHAVIOR:\n  Running jj-stack without arguments analyzes and displays the current\n  graph of stacked bookmarks.\n\nEXAMPLES:\n  jj-stack                        # Show change graph\n  jj-stack submit feature-branch  # Submit feature-branch and downstack as PRs\n  jj-stack submit feature-branch --dry-run  # Preview what would be done\n  jj-stack submit feature-branch --remote upstream  # Use a specific remote\n  jj-stack auth test              # Test GitHub authentication\n\nFor more information, visit: https://github.com/keanemind/jj-stack\n";
 
 async function resolveRemoteName(remotes, userSpecified) {
+  var githubInstance = "github.com";
   if (userSpecified !== undefined) {
     var foundRemote = remotes.find(function (r) {
           return r.name === userSpecified;
         });
     if (foundRemote !== undefined) {
-      if (!JjUtilsJs.isGitHubRemote(foundRemote.url)) {
+      if (!JjUtilsJs.hasHost(foundRemote.url, githubInstance)) {
         console.error("❌ Remote '" + userSpecified + "' is not a GitHub remote. Only GitHub remotes are supported.");
         process.exit(1);
         Js_exn.raiseError("");
@@ -43,7 +44,7 @@ async function resolveRemoteName(remotes, userSpecified) {
     }
   }
   var githubRemotes = remotes.filter(function (r) {
-        return JjUtilsJs.isGitHubRemote(r.url);
+        return JjUtilsJs.hasHost(r.url, githubInstance);
       });
   var match = githubRemotes.length;
   if (match !== 0) {
@@ -177,7 +178,7 @@ async function main() {
 
 export {
   createJjFunctions ,
-  isGitHubRemote ,
+  hasHost ,
   help ,
   resolveRemoteName ,
   main ,

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,22 @@
+import assert from "assert/strict";
+
+import { parseUrlDetails } from './auth.js';
+
+suite("parseUrlDetails", () => {
+
+  test('ssh - github ', () =>  {
+    assert.deepStrictEqual({
+	host: "github.com",
+	owner: "keanemind",
+	repo: "jj-stack",
+      }, parseUrlDetails('ssh://git@github.com/keanemind/jj-stack.git'));
+  });
+
+  test('git - github enterprise', () =>  {
+    assert.deepStrictEqual({
+	host: "myorg.ghe.com",
+	owner: "MyOrg",
+	repo: "repo",
+      }, parseUrlDetails('myorg@myorg.ghe.com:MyOrg/repo.git'));
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@ const execFileAsync = promisify(execFile);
 
 export interface AuthConfig {
   token: string;
+  host: string;  // usually github.com, unless using github enterprise
   source: "gh-cli" | "env-var";
 }
 
@@ -34,16 +35,17 @@ export interface AuthFailure {
 /**
  * Check if GitHub CLI is available and authenticated
  */
-async function getGitHubCLIAuth(): Promise<string | null> {
+async function getGitHubCLIAuth(host: string): Promise<string | null> {
   try {
+    
     // First check if gh CLI is available
     await execFileAsync("gh", ["--version"]);
 
     // Check if user is authenticated
-    await execFileAsync("gh", ["auth", "status"]);
+    await execFileAsync("gh", ["auth", "status", "--hostname", host]);
 
     // If we get here, user is authenticated. Get the token.
-    const tokenResult = await execFileAsync("gh", ["auth", "token"]);
+    const tokenResult = await execFileAsync("gh", ["auth", "token", "--hostname", host]);
     const token = tokenResult.stdout.trim();
 
     if (token) {
@@ -73,9 +75,9 @@ function getEnvironmentToken(): string | null {
 /**
  * Validate that a token works by making a test API call
  */
-async function validateToken(token: string): Promise<boolean> {
+async function validateToken(host: string, token: string): Promise<boolean> {
   try {
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({ auth: token, baseUrl:  getAPIUrl(host) });
 
     // Test the token by getting user info
     await octokit.rest.users.getAuthenticated();
@@ -86,7 +88,7 @@ async function validateToken(token: string): Promise<boolean> {
 }
 
 export async function getAuthDetails(authConfig: AuthConfig) {
-  const octokit = new Octokit({ auth: authConfig.token });
+  const octokit = new Octokit({ auth: authConfig.token, baseUrl: getAPIUrl(authConfig.host) });
   const user = await octokit.rest.users.getAuthenticated();
   const response = await octokit.request("GET /user");
   const scopes = response.headers["x-oauth-scopes"]?.split(", ") || [];
@@ -104,13 +106,15 @@ export async function getAuthDetails(authConfig: AuthConfig) {
  * 2. Environment variables (GITHUB_TOKEN or GH_TOKEN)
  * 3. Return failure with instructions
  */
-export async function getGitHubAuth(): Promise<AuthSuccess | AuthFailure> {
+export async function getGitHubAuth(remoteName: string): Promise<AuthSuccess | AuthFailure> {
+  const urlDetails = await getUrlDetailsForRemote(remoteName);
+
   // 1. Try GitHub CLI first
-  const ghCliToken = await getGitHubCLIAuth();
+  const ghCliToken = await getGitHubCLIAuth(urlDetails.host);
   if (ghCliToken) {
     return {
       kind: "success",
-      config: { token: ghCliToken, source: "gh-cli" },
+      config: { token: ghCliToken, source: "gh-cli", host: urlDetails.host }, 
     };
   }
 
@@ -118,10 +122,10 @@ export async function getGitHubAuth(): Promise<AuthSuccess | AuthFailure> {
   const envToken = getEnvironmentToken();
   if (envToken) {
     // Validate the token
-    if (await validateToken(envToken)) {
+    if (await validateToken(urlDetails.host, envToken)) {
       return {
         kind: "success",
-        config: { token: envToken, source: "env-var" },
+        config: { token: envToken, source: "env-var", host: urlDetails.host}, // TODO
       };
     } else {
       logger.debug("GitHub token from environment variable is invalid");
@@ -138,3 +142,52 @@ export async function getGitHubAuth(): Promise<AuthSuccess | AuthFailure> {
     reason: "no-auth-found",
   };
 }
+
+
+export interface UrlDetails {
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+export async function getUrlDetailsForRemote(remoteName: string): Promise<UrlDetails> {
+  let remoteUrlResult = await execFileAsync("git", ["remote", "get-url", remoteName]);
+  let remoteUrl = remoteUrlResult.stdout.trim();
+
+  return parseUrlDetails(remoteUrl);
+
+}
+
+export function parseUrlDetails(remoteUrl: string): UrlDetails {
+  // parse ssh based remote URLs
+  if (remoteUrl.startsWith("ssh")) {
+    const url = new URL(remoteUrl);
+    const [ _, owner, repo ] = url.pathname.split("/");
+    return {
+      host: url.host,
+      owner,
+      repo: repo.replace(/.git$/, ''),
+    };
+  }
+
+  // parse the user-scoped form of of SSH urls used by github enterprise, 
+  // for example: myorg@myorg.ghe.com:MyOrg/repo.git
+  let match = remoteUrl.match(/.*\@(.*):(.*)\/(.*)(.git?)/);
+  if (!match) {
+    throw new Error(`could not guess host from remote URL ${remoteUrl}`);
+  }
+  return {
+    host: match[1],
+    owner: match[2],
+    repo: match[3],
+  }
+}
+
+
+export function getAPIUrl(host: string): string {
+  if (host === "github.com") {
+    return "https://api.github.com";
+  }
+  return `https://${host}/api/v3`;
+}
+

--- a/src/lib/jjUtils.ts
+++ b/src/lib/jjUtils.ts
@@ -38,6 +38,10 @@ export function isGitHubRemote(remoteUrl: string): boolean {
   return /github\.com[:/]/.test(remoteUrl);
 }
 
+export function hasHost(remoteUrl: string, githubInstanceHost: string): boolean {
+	return true; // TOOD
+}
+
 /**
  * Filter a list of remotes to only include GitHub.com remotes
  */

--- a/src/lib/submit.ts
+++ b/src/lib/submit.ts
@@ -1,11 +1,12 @@
 import { Octokit } from "octokit";
-import { getGitHubAuth } from "./auth.js";
+import { getGitHubAuth, getUrlDetailsForRemote, getAPIUrl } from "./auth.js";
 import type {
   Bookmark,
   ChangeGraph,
   BookmarkSegment,
   NarrowedBookmarkSegment,
 } from "./jjTypes.js";
+import { logger } from "./logger.js";
 import type { JjFunctions } from "./jjUtils.js";
 import { isGitHubRemote } from "./jjUtils.js";
 import * as v from "valibot";
@@ -126,6 +127,7 @@ export function analyzeSubmissionGraph(
 /**
  * Extract GitHub owner and repo from jj git remote URL
  */
+// TODO: can we build this into auth?
 export async function getGitHubRepoInfo(
   jj: JjFunctions,
   remoteName: string,
@@ -142,35 +144,9 @@ export async function getGitHubRepoInfo(
     throw new Error(`No '${remoteName}' remote found`);
   }
 
-  const remoteUrl = targetRemote.url;
+  let urlDetails = await getUrlDetailsForRemote(targetRemote.name);
 
-  // Validate that this is a GitHub remote
-  if (!isGitHubRemote(remoteUrl)) {
-    throw new Error(
-      `Remote '${remoteName}' does not point to GitHub.com: ${remoteUrl}`,
-    );
-  }
-
-  // Parse GitHub URLs - support both HTTPS and SSH formats
-  // HTTPS: https://github.com/owner/repo.git
-  // SSH: git@github.com:owner/repo.git
-  const match = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
-
-  if (!match) {
-    throw new Error(
-      `Could not parse GitHub repository from remote URL: ${remoteUrl}`,
-    );
-  }
-
-  const owner = match[1];
-  let repo = match[2];
-
-  // Remove .git suffix if present
-  if (repo.endsWith(".git")) {
-    repo = repo.slice(0, -4);
-  }
-
-  return { owner, repo };
+  return { owner: urlDetails.owner, repo: urlDetails.repo };
 }
 
 /**
@@ -181,11 +157,12 @@ export async function getGitHubConfig(
   remoteName: string,
 ): Promise<GitHubConfig> {
   // Get authentication using the auth utility
-  const authResult = await getGitHubAuth();
+  const authResult = await getGitHubAuth(remoteName);
+
   if (authResult.kind !== "success") {
     throw new Error(`GitHub authentication failed: ${authResult.reason}`);
   }
-  const octokit = new Octokit({ auth: authResult.config.token });
+  const octokit = new Octokit({ auth: authResult.config.token, baseUrl: getAPIUrl(authResult.config.host) });
 
   // Try to extract owner/repo from git remote, fall back to environment variables
   let owner = process.env.GITHUB_OWNER;


### PR DESCRIPTION
Github enterprise behaves like github in most ways. But each github enterprise instance lives at its own domain that is not github.com. For example, mycompany.ghe.com.

This change allows jj-stack work with github enterprise urls by making a few changes:

* avoid any hardcoded checks for github.com URLs
* infer the github API base URL from the specified remote's URL