### PR TITLE
refactor: use plain links in comment bodies

### DIFF
--- a/src/lib/submit.ts
+++ b/src/lib/submit.ts
@@ -335,9 +335,9 @@ export async function createOrUpdateStackComment(
     const stackItem = prCommentData.stack[i];
     const isCurrent = i === currentBookmarkIdx;
     if (isCurrent) {
-      commentBody += `1. **${stackItem.bookmarkName} ${stackCommentThisPRText}**\n`;
+      commentBody += `1. **${stackItem.prUrl} ${stackCommentThisPRText}**\n`;
     } else {
-      commentBody += `1. [${stackItem.bookmarkName}](${stackItem.prUrl})\n`;
+      commentBody += `1. ${stackItem.prUrl}\n`;
     }
   }
 


### PR DESCRIPTION
When using jj, bookmark names are auto-generated as `push-<changeid>`, which are cryptic and unreadable in stack comments. Previously, the stack comment rendered links using the bookmark name as display text:

```
  1. [push-abc123](https://github.com/owner/repo/pull/42)
```

GitHub automatically renders plain PR URLs as rich links showing the PR title and number. By emitting plain URLs instead, the comments become much more readable without any extra API calls:

```
  1. https://github.com/owner/repo/pull/42
```

Fixes #6