### PR TITLE
fix: submit reordered stack without triggering indirect merge

### DIFF
--- a/src/lib/submit.test.ts
+++ b/src/lib/submit.test.ts
@@ -1,0 +1,215 @@
+import {
+  executeSubmissionPlan,
+  type SubmissionPlan,
+  type GitHubConfig,
+  type PullRequest,
+} from "./submit.js";
+import type { Bookmark } from "./jjTypes.js";
+import type { JjFunctions } from "./jjUtils.js";
+import assert from "assert/strict";
+
+suite("submit operations", () => {
+  test("interleaves push and base update operations", async () => {
+    console.log(
+      "\n=== Testing interleaved push and base update operations ===",
+    );
+
+    // This test verifies that push and base update operations are interleaved
+    // to prevent indirect merge conditions
+    // Bug: pushing all branches first, then updating all bases creates a window
+    //      where PRs can have new commits but old bases, triggering indirect merges
+
+    const operationLog: string[] = [];
+
+    const mockGitHubConfig: GitHubConfig = {
+      owner: "test",
+      repo: "repo",
+      octokit: {
+        rest: {
+          pulls: {
+            update: async ({
+              pull_number,
+              base,
+            }: {
+              pull_number: number;
+              base: string;
+            }) => {
+              operationLog.push(`UPDATE_BASE(PR${pull_number}, ${base})`);
+              return {
+                data: {
+                  number: pull_number,
+                  html_url: `https://github.com/test/repo/pull/${pull_number}`,
+                  title: "Test PR",
+                  base: { ref: base, sha: "abc" },
+                  head: { ref: "test", sha: "def" },
+                } as PullRequest,
+              };
+            },
+          },
+          issues: {
+            listComments: async () => ({ data: [] }),
+            createComment: async () => ({ data: { id: 1 } }),
+          },
+        },
+      } as any,
+    };
+
+    const mockJj: JjFunctions = {
+      gitFetch: () => Promise.resolve(),
+      getMyBookmarks: () => Promise.resolve([]),
+      getBranchChangesPaginated: () => Promise.resolve([]),
+      getGitRemoteList: () => Promise.resolve([]),
+      getDefaultBranch: () => Promise.resolve("main"),
+      pushBookmark: async (name: string) => {
+        operationLog.push(`PUSH(${name})`);
+      },
+    };
+
+    const bookmarkB: Bookmark = {
+      name: "bookmark-b",
+      commitId: "commit_b",
+      changeId: "change_b",
+      hasRemote: false,
+      isSynced: false,
+    };
+
+    const bookmarkC: Bookmark = {
+      name: "bookmark-c",
+      commitId: "commit_c",
+      changeId: "change_c",
+      hasRemote: false,
+      isSynced: false,
+    };
+
+    const bookmarkA: Bookmark = {
+      name: "bookmark-a",
+      commitId: "commit_a",
+      changeId: "change_a",
+      hasRemote: false,
+      isSynced: false,
+    };
+
+    const plan: SubmissionPlan = {
+      targetBookmark: "bookmark-a",
+      bookmarksToSubmit: [bookmarkB, bookmarkC, bookmarkA],
+      bookmarksNeedingPush: [bookmarkB, bookmarkC, bookmarkA],
+      bookmarksNeedingPR: [], // PRs already exist in reorder stack scenario
+      bookmarksNeedingPRBaseUpdate: [
+        {
+          bookmark: bookmarkB,
+          currentBaseBranch: "old-base-b",
+          expectedBaseBranchOptions: ["main"],
+          pr: {
+            number: 2,
+            html_url: "https://github.com/test/repo/pull/2",
+            title: "B",
+            base: { ref: "old-base-b", sha: "abc" },
+            head: { ref: "bookmark-b", sha: "def" },
+          } as PullRequest,
+        },
+        {
+          bookmark: bookmarkC,
+          currentBaseBranch: "old-base-c",
+          expectedBaseBranchOptions: ["bookmark-b"],
+          pr: {
+            number: 3,
+            html_url: "https://github.com/test/repo/pull/3",
+            title: "C",
+            base: { ref: "old-base-c", sha: "ghi" },
+            head: { ref: "bookmark-c", sha: "jkl" },
+          } as PullRequest,
+        },
+        {
+          bookmark: bookmarkA,
+          currentBaseBranch: "old-base-a",
+          expectedBaseBranchOptions: ["bookmark-c"],
+          pr: {
+            number: 1,
+            html_url: "https://github.com/test/repo/pull/1",
+            title: "A",
+            base: { ref: "old-base-a", sha: "mno" },
+            head: { ref: "bookmark-a", sha: "pqr" },
+          } as PullRequest,
+        },
+      ],
+      repoInfo: { owner: "test", repo: "repo" },
+      existingPRs: new Map(),
+      remoteName: "origin",
+    };
+
+    await executeSubmissionPlan(mockJj, plan, mockGitHubConfig);
+
+    console.log("Operation sequence:", operationLog);
+
+    // Verify interleaved operations: each push should be followed by its base update
+    // Expected: PUSH(B), UPDATE_BASE(PR2), PUSH(C), UPDATE_BASE(PR3), PUSH(A), UPDATE_BASE(PR1)
+
+    // Find indices of operations
+    const pushBIdx = operationLog.indexOf("PUSH(bookmark-b)");
+    const updateBIdx = operationLog.indexOf("UPDATE_BASE(PR2, main)");
+    const pushCIdx = operationLog.indexOf("PUSH(bookmark-c)");
+    const updateCIdx = operationLog.indexOf("UPDATE_BASE(PR3, bookmark-b)");
+    const pushAIdx = operationLog.indexOf("PUSH(bookmark-a)");
+    const updateAIdx = operationLog.indexOf("UPDATE_BASE(PR1, bookmark-c)");
+
+    // Verify all operations occurred
+    assert.ok(pushBIdx >= 0, "Expected PUSH(bookmark-b) to occur");
+    assert.ok(updateBIdx >= 0, "Expected UPDATE_BASE(PR2) to occur");
+    assert.ok(pushCIdx >= 0, "Expected PUSH(bookmark-c) to occur");
+    assert.ok(updateCIdx >= 0, "Expected UPDATE_BASE(PR3) to occur");
+    assert.ok(pushAIdx >= 0, "Expected PUSH(bookmark-a) to occur");
+    assert.ok(updateAIdx >= 0, "Expected UPDATE_BASE(PR1) to occur");
+
+    // Critical assertions: verify interleaved order
+    assert.ok(
+      pushBIdx < updateBIdx,
+      `Expected PUSH(bookmark-b) before UPDATE_BASE(PR2), but got indices ${pushBIdx}, ${updateBIdx}. ` +
+        `Bug: if all pushes happen first, indirect merge conditions can occur.`,
+    );
+
+    assert.ok(
+      updateBIdx < pushCIdx,
+      `Expected UPDATE_BASE(PR2) before PUSH(bookmark-c), got indices ${updateBIdx}, ${pushCIdx}. ` +
+        `Operations should be interleaved, not batched.`,
+    );
+
+    assert.ok(
+      pushCIdx < updateCIdx,
+      `Expected PUSH(bookmark-c) before UPDATE_BASE(PR3), but got indices ${pushCIdx}, ${updateCIdx}`,
+    );
+
+    assert.ok(
+      updateCIdx < pushAIdx,
+      `Expected UPDATE_BASE(PR3) before PUSH(bookmark-a), got indices ${updateCIdx}, ${pushAIdx}`,
+    );
+
+    assert.ok(
+      pushAIdx < updateAIdx,
+      `Expected PUSH(bookmark-a) before UPDATE_BASE(PR1), but got indices ${pushAIdx}, ${updateAIdx}`,
+    );
+
+    // Verify operations are in strict interleaved sequence (no batching)
+    const expectedPattern = [
+      "PUSH(bookmark-b)",
+      "UPDATE_BASE(PR2, main)",
+      "PUSH(bookmark-c)",
+      "UPDATE_BASE(PR3, bookmark-b)",
+      "PUSH(bookmark-a)",
+      "UPDATE_BASE(PR1, bookmark-c)",
+    ];
+
+    // Filter operation log to only push/update operations
+    const relevantOps = operationLog.filter(
+      (op) => op.startsWith("PUSH(") || op.startsWith("UPDATE_BASE("),
+    );
+
+    assert.deepStrictEqual(
+      relevantOps,
+      expectedPattern,
+      `Expected strict interleaved pattern, but got: ${JSON.stringify(relevantOps)}. ` +
+        `This ensures no indirect merge conditions can occur.`,
+    );
+
+    console.log("✓ Push and base update operations are correctly interleaved");
+  });
+});

--- a/src/lib/submit.ts
+++ b/src/lib/submit.ts
@@ -584,54 +584,58 @@ export async function executeSubmissionPlan(
   };
 
   try {
-    // Push all bookmarks that need pushing
-    for (const bookmark of plan.bookmarksNeedingPush) {
-      try {
-        callbacks?.onPushStarted?.(bookmark, plan.remoteName);
-        await jj.pushBookmark(bookmark.name, plan.remoteName);
-        callbacks?.onPushCompleted?.(bookmark, plan.remoteName);
-        result.pushedBookmarks.push(bookmark);
-      } catch (error) {
-        throw new Error(`Error pushing ${bookmark.name}: ${String(error)}`);
-      }
-    }
-
     const bookmarkToPR = new Map<string, PullRequest>(plan.existingPRs);
 
-    // Update PR bases for existing PRs that need it (in order from bottom to top)
-    for (const {
-      bookmark,
-      currentBaseBranch,
-      expectedBaseBranchOptions,
-      pr,
-    } of plan.bookmarksNeedingPRBaseUpdate) {
-      try {
-        if (expectedBaseBranchOptions.length !== 1) {
+    // CRITICAL: Interleave push and base update operations to prevent indirect merges
+    // Process bookmarks from bottom to top of stack
+    // For each bookmark: push first, then immediately update its PR base if needed
+    for (const bookmark of plan.bookmarksToSubmit) {
+      // Step 1: Push the bookmark if needed
+      if (plan.bookmarksNeedingPush.some((b) => b.name === bookmark.name)) {
+        try {
+          callbacks?.onPushStarted?.(bookmark, plan.remoteName);
+          await jj.pushBookmark(bookmark.name, plan.remoteName);
+          callbacks?.onPushCompleted?.(bookmark, plan.remoteName);
+          result.pushedBookmarks.push(bookmark);
+        } catch (error) {
+          throw new Error(`Error pushing ${bookmark.name}: ${String(error)}`);
+        }
+      }
+
+      // Step 2: Immediately update PR base for this bookmark if needed
+      const baseUpdate = plan.bookmarksNeedingPRBaseUpdate.find(
+        (u) => u.bookmark.name === bookmark.name,
+      );
+      if (baseUpdate) {
+        try {
+          if (baseUpdate.expectedBaseBranchOptions.length !== 1) {
+            throw new Error(
+              `Expected exactly one base branch option for ${bookmark.name}, but got ${baseUpdate.expectedBaseBranchOptions.length}`,
+            );
+          }
+
+          callbacks?.onPRBaseUpdateStarted?.(
+            bookmark,
+            baseUpdate.currentBaseBranch,
+            baseUpdate.expectedBaseBranchOptions[0],
+          );
+
+          const updatedPR = await updatePRBase(
+            githubConfig.octokit,
+            githubConfig.owner,
+            githubConfig.repo,
+            baseUpdate.pr.number,
+            baseUpdate.expectedBaseBranchOptions[0],
+          );
+
+          callbacks?.onPRBaseUpdateCompleted?.(bookmark, updatedPR);
+          result.updatedPRs.push({ bookmark, pr: updatedPR });
+          bookmarkToPR.set(bookmark.name, updatedPR);
+        } catch (error) {
           throw new Error(
-            `Expected exactly one base branch option for ${bookmark.name}, but got ${expectedBaseBranchOptions.length}`,
+            `Error updating PR base for ${bookmark.name}: ${String(error)}`,
           );
         }
-
-        callbacks?.onPRBaseUpdateStarted?.(
-          bookmark,
-          currentBaseBranch,
-          expectedBaseBranchOptions[0],
-        );
-
-        const updatedPR = await updatePRBase(
-          githubConfig.octokit,
-          githubConfig.owner,
-          githubConfig.repo,
-          pr.number,
-          expectedBaseBranchOptions[0],
-        );
-
-        callbacks?.onPRBaseUpdateCompleted?.(bookmark, updatedPR);
-        result.updatedPRs.push({ bookmark, pr: updatedPR });
-      } catch (error) {
-        throw new Error(
-          `Error updating PR base for ${bookmark.name}: ${String(error)}`,
-        );
       }
     }
 


### PR DESCRIPTION
## Description

This interleaves "git push" and "update PR base"operations to ensure conditions for GitHub [indirect merges](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#indirect-merges) never arise.

Closes #21.

### Problem

**Scenario**: Reorder from trunk()→A→B→C to trunk()→B→C→A (rebased to B', C', A')

1. Push B' → branch B = [b1', b2']
2. Push C' → branch C = [b1', b2', c1', c2']
3. Push A' → branch A = [b1', b2', c1', c2', a1', a2']
   At this moment:
   - `PR #2` (B→A): head (B) = [b1', b2']
                  base (A) = [b1', b2', c1', c2', a1', a2']
   - ALL of B's commits are in A
   - ❌  INDIRECT MERGE CONDITION EXISTS
4. Update `PR #2` base: A → main (but too late -- GH has already indirectly merged B)

## Validation

New test suite was added for this scenario and confirmed to be failing. Fix was added and new test suite passes.